### PR TITLE
Ex02: Update: PokeInfoクラスに分類（genus）を追加

### DIFF
--- a/ex02/pokedex/src/models/language.ts
+++ b/ex02/pokedex/src/models/language.ts
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/17 08:22:30 by dnakano           #+#    #+#             */
-/*   Updated: 2021/01/17 09:01:44 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/01/19 11:58:08 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,4 +33,17 @@ export const findNameInLang = (
     return "N/A";
   }
   return nameInLang.name;
+};
+
+export const findGenusInLang = (
+  nameInLangs: { language: { name: Language }; genus: string }[],
+  langDesignation: Language
+): string => {
+  const nameInLang = nameInLangs.find(nameInLang => {
+    return nameInLang.language.name === langDesignation;
+  });
+  if (nameInLang === void 0) {
+    return "N/A";
+  }
+  return nameInLang.genus;
 };

--- a/ex02/pokedex/src/models/pokeInfo.ts
+++ b/ex02/pokedex/src/models/pokeInfo.ts
@@ -6,7 +6,7 @@
 /*   By: dnakano <dnakano@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/16 22:21:35 by dnakano           #+#    #+#             */
-/*   Updated: 2021/01/17 13:14:55 by dnakano          ###   ########.fr       */
+/*   Updated: 2021/01/19 11:58:54 by dnakano          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,13 +14,14 @@ import axios from "axios";
 import Pokemon, { POKEAPI_ROOT } from "./pokemon";
 import PokeStats, { getPokeStats } from "./pokeStats";
 import PokeType, { fetchPokeTypes } from "./pokeType";
-import { findNameInLang, Language } from "./language";
+import { findNameInLang, findGenusInLang, Language } from "./language";
 
 export default class PokeInfo extends Pokemon {
   constructor(
     pokemon: Pokemon,
     public readonly weight: number,
     public readonly height: number,
+    public readonly genus: string,
     public readonly types: PokeType[],
     public readonly stats: PokeStats
   ) {
@@ -32,6 +33,7 @@ export const emptyPokeInfo = new PokeInfo(
   new Pokemon(0, "", ""),
   0,
   0,
+  "",
   [],
   new PokeStats(0, 0, 0, 0, 0, 0, 0, 0)
 );
@@ -53,6 +55,7 @@ export const fetchPokeInfoById = async (
     ),
     resPokeInfo.data.weight,
     resPokeInfo.data.height,
+    findGenusInLang(resPokeSpecies.data.genera, lang),
     pokeTypes,
     getPokeStats(resPokeInfo.data.stats)
   );


### PR DESCRIPTION
Issue #10 の要望追加しました。確認をお願いします！

- メンバーにgenusを追加
- Nameと同様に言語に応じた名前を格納するように処理してます。
- PokeInfo.tsのヘッダー周りがとやさんの変更とコンフリクトするかもしれません。（あるとすれば多分ヘッダ）
- 再pushする前にpull mainしてコンフリクト解消の上マージしてください！わからなければ聞いてください。